### PR TITLE
Use eslint to enforce good const/let/var usage

### DIFF
--- a/GUIDELINES.md
+++ b/GUIDELINES.md
@@ -148,18 +148,24 @@ Add a `make` target
 ### Some things linting will catch
 
 Unused variables, proper casing of function and variable names, undeclared global variables,
-modification of global variables, missing semi-colons. Catching unused variables is great
-because this might alert you to a typo in your code. Modifying global variables could have
-adverse affects on other code within your system, including dependencies, if the other code
-is not aware of the modifications. For these and many other reasons, we think linting is a
+modification of global variables, missing semi-colons, consistent use of const/let/var.
+Catching unused variables is great because this might alert you to a typo in your code.
+Modifying global variables could have adverse affects on other code within your system,
+including dependencies, if the other code is not aware of the modifications. Using `const`
+is preferred to `var`. If a variable must be mutable, use `let` (`var` is also allowed for
+mutable variables for cases where `let` may cause performance issues, but is restricted to
+block scope, so will act like `let`. For these and many other reasons, we think linting is a
 'good thing'.
 
 ### Some things linting _won't_ catch, but that you should consider
 
-At this point, we eschew any Node.js version below 4.x. This means, that usage of ES6
-features is possible. And there are some good features to take advatage of. Here are
-some of our recommendations.
+At this point, we eschew any Node.js version below 4.x. This means that usage of ES6
+features is possible, and there are some good features to take advantage of. Here are some
+of our recommendations.
 
+* Use `let` and `const` instead of `var`. There is rarely ever a valid case for using
+  `var` in modern Javascript code. If the variable is immutable (which we believe most
+  should be), use `const`. If the variable may be written, use `let`.
 * Use promises for asynchronous code execution, where appropriate. (Consider using
   bucharest-gold/fidelity).
 * Use the new ES6 `class` keyword to create classes, and avoid direct manipulation

--- a/GUIDELINES.md
+++ b/GUIDELINES.md
@@ -112,7 +112,13 @@ plugins for `eslint` in our builds.
 First, add an `.eslintrc.json` file to your project and put this in there.
 
     {
-      "extends": "semistandard"
+      "extends": "semistandard",
+
+      "rules": {
+        "prefer-const": "error",
+        "block-scoped-var": "error",
+        "no-use-before-define": ["error", "nofunc"],
+      }
     }
 
 Then install `eslint` and the `semistandard` and dependent plugins.
@@ -154,12 +160,9 @@ At this point, we eschew any Node.js version below 4.x. This means, that usage o
 features is possible. And there are some good features to take advatage of. Here are
 some of our recommendations.
 
-* Use `let` and `const` instead of `var`. There is rarely ever a valid case for using
-  `var` in modern Javascript code. If the variable is immutable (which we believe most
-  should be), use `const`. If the variable may be written, use `let`.
 * Use promises for asynchronous code execution, where appropriate. (Consider using
   bucharest-gold/fidelity).
-* Use the new ES6 `class` keyword to create classess, and avoid direct manipulation
+* Use the new ES6 `class` keyword to create classes, and avoid direct manipulation
   of prototypes.
 * Use `Symbol`s to keep private data private. There are a few ways to achieve data privacy
   in Javascript. We've found that using a `Symbol` as a key is the most performant.


### PR DESCRIPTION
Motivation:
Currently the guidelines put this into the "linting won't catch this" section, because we've just been using plain semistandard.

Modification:
* Add prefer-const rule, which will force usage of const if an identifier is never reassigned. More info: http://eslint.org/docs/rules/prefer-const

* Add no-use-before-define rule, which will prevent ReferenceErrors being thrown due to "temporal dead zone" issues with const/let. More info: http://eslint.org/docs/rules/no-use-before-define

* Add block-scoped-var rule, which will force var to act like let. The current guidelines recommend against using var, and instead using let for mutable variables. Unfortunately, let currently doesn't perform as well as const or var:

  https://github.com/nodejs/node/issues/8637#issuecomment-248656241

  More info on this rule: http://eslint.org/docs/rules/block-scoped-var

* Remove the recommendation to check for this manually.


Note: If you're happy with the first two rules, but would prefer to completely disallow var, even with the current performance issues; I can modify this commit to use the no-var rule instead of the block-scoped-var rule. Let me know what you think! :)