### PR TITLE
docs: fix incorrect release script invocation

### DIFF
--- a/GUIDELINES.md
+++ b/GUIDELINES.md
@@ -283,7 +283,7 @@ formatted appropriately.
 
 Assuming your local master branch is up to date, the next steps are.
 
-1. Run standard-version: `npm run standard-version`
+1. Run standard-version: `npm run release`
 2. Push to GitHub: `git push --follow-tags origin master`
 3. Publish to npmjs.com: `npm publish`
 4. Assuming all goes well, head over to your project on github and update the


### PR DESCRIPTION
Hi, popping over from the `conventional-changelog/standard-version` team as I happened to notice you started using it. Skimmed over your guidelines out of interest and happened to note that you have an inconsistent npm script and invocation in it. This modifies the invocation to match the npm script `release`. 

Personally, I encourage heavy usage of `chore`, `docs`, `refactor` and `style` types in commits to master to enable fast skimming of the log. For example, `chore(ci)` for modifying ci configuration files is a frequent actor in our commit logs that we then later just ignore when skimming the logs.

Hope you like the tool!